### PR TITLE
docs: add operator UX spine to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,6 +5,23 @@
 - Establish v1 scope: personal memory first
 - Create initial repo docs, architecture notes, and tracked issues
 
+## Packaging / operator UX spine
+Goal: make Mneme easier to run, inspect, and deploy.
+
+Deliverables:
+- clearer split between `protocol/`, `runtime/`, and `distribution/`
+- one obvious operator-facing CLI surface
+- tiny sanitized sample workspace
+- install/migration guidance
+- cron/systemd deployment examples
+- strict failure propagation and schema-backed validation
+
+Success criteria:
+- Mneme feels like a product, not a bag of scripts
+- operators can discover the right entrypoint quickly
+- deployment docs are boring and repeatable
+- runtime checks fail loudly instead of faking success
+
 ## Phase 1 — Raw evidence ingestion
 Goal: collect the things an agent actually did and saw.
 


### PR DESCRIPTION
## Summary
- add a small roadmap section for packaging/operator UX
- make the protocol/runtime/distribution split explicit
- call out deployability and strict failure propagation as first-class goals

## Why
Issue #12 argues that Mneme should steal six6's packaging skeleton without inheriting its weak runtime safety model. This is the smallest useful docs change that records that direction without overcommitting the final implementation.