### PR TITLE
harden privacy defaults for local and runtime flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Mneme v1 is successful if:
 Mneme now includes its first live check:
 
 - [`scripts/mneme_memory_check.py`](./scripts/mneme_memory_check.py) — verify memory config, index health, embeddings readiness, and live recall
-- [`scripts/mneme_ingest_memory.py`](./scripts/mneme_ingest_memory.py) — ingest OpenClaw memory files into raw Mneme evidence JSONL
+- [`scripts/mneme_ingest_memory.py`](./scripts/mneme_ingest_memory.py) — ingest OpenClaw memory files into raw Mneme evidence JSONL (workspace-relative URIs by default)
 - [`scripts/mneme_compile_memory.py`](./scripts/mneme_compile_memory.py) — generate a first-pass compiled memory pack from OpenClaw-style notes
 - [`scripts/mneme_secret_scrub.py`](./scripts/mneme_secret_scrub.py) — scan memory files for likely secrets and redact obvious raw tokens/passwords
 - [`scripts/mneme_memory_drift.py`](./scripts/mneme_memory_drift.py) — detect likely contradictions and stale facts in memory files
@@ -114,8 +114,8 @@ Mneme now includes its first live check:
 - [`scripts/mneme_materialize_candidates.py`](./scripts/mneme_materialize_candidates.py) — turn validated LLM candidate entries into compiled outputs
 - [`scripts/mneme_llm_roundtrip.py`](./scripts/mneme_llm_roundtrip.py) — run the end-to-end LLM-assisted compile loop for one category
 - [`scripts/mneme_merge_pack.py`](./scripts/mneme_merge_pack.py) — merge reviewed category outputs into one compiled pack
-- [`scripts/mneme_runtime_orchestrate.py`](./scripts/mneme_runtime_orchestrate.py) — prepare/apply the runtime agent-dispatch seam for Mneme compile runs
-- [`scripts/mneme_runtime_batch.py`](./scripts/mneme_runtime_batch.py) — prepare/apply multi-category runtime compile runs
+- [`scripts/mneme_runtime_orchestrate.py`](./scripts/mneme_runtime_orchestrate.py) — prepare/apply the runtime agent-dispatch seam for Mneme compile runs (explicit `--allow-agent-export` required)
+- [`scripts/mneme_runtime_batch.py`](./scripts/mneme_runtime_batch.py) — prepare/apply multi-category runtime compile runs (explicit `--allow-agent-export` required)
 
 ## Repo hygiene
 

--- a/docs/runtime-batch.md
+++ b/docs/runtime-batch.md
@@ -25,7 +25,8 @@ so the runtime can iterate category tasks and then merge one reviewed pack.
 ```bash
 ./scripts/mneme_runtime_batch.py prepare-batch \
   --root /path/to/workspace \
-  --out /path/to/output/batch
+  --out /path/to/output/batch \
+  --allow-agent-export
 ```
 
 This writes:

--- a/docs/runtime-orchestration.md
+++ b/docs/runtime-orchestration.md
@@ -31,7 +31,8 @@ This script is that seam.
 ```bash
 ./scripts/mneme_runtime_orchestrate.py prepare-task \
   --root /path/to/workspace \
-  --category projects
+  --category projects \
+  --allow-agent-export
 ```
 
 This outputs JSON containing:
@@ -39,6 +40,8 @@ This outputs JSON containing:
 - raw/bundle/materialize paths
 - a fully assembled `taskPrompt`
 - summary of the underlying roundtrip prep
+
+You must pass `--allow-agent-export` explicitly because `taskPrompt` may be sent off-box by the runtime.
 
 The OpenClaw runtime can take `taskPrompt` and send it to an agent.
 

--- a/scripts/mneme_ingest_memory.py
+++ b/scripts/mneme_ingest_memory.py
@@ -97,20 +97,26 @@ def observed_at(path: Path) -> str | None:
     return f"{m.group(1)}T00:00:00Z"
 
 
-def build_source(root: Path, path: Path, captured_at: str) -> dict:
-    rel = str(path.relative_to(root))
+def build_source(
+    root: Path,
+    path: Path,
+    captured_at: str,
+    include_absolute_uri: bool = False,
+) -> dict:
+    rel = path.relative_to(root).as_posix()
     text = path.read_text(errors="replace")
     digest = sha256_text(text)
-    return {
+    source = {
         "id": f"src:{source_type(path)}:{rel}:sha256:{digest[:12]}",
         "sourceType": source_type(path),
-        "uri": path.resolve().as_uri(),
+        "uri": path.resolve().as_uri() if include_absolute_uri else f"workspace:///{rel}",
         "workspacePath": rel,
         "title": path.name,
         "capturedAt": captured_at,
         "contentHash": f"sha256:{digest}",
         "mimeType": "text/markdown",
     }
+    return source
 
 
 def iter_memory_lines(path: Path) -> Iterable[tuple[int, str]]:
@@ -226,6 +232,11 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Ingest OpenClaw memory files into Mneme raw evidence JSONL.")
     ap.add_argument("--root", default=".", help="Workspace root")
     ap.add_argument("--out", default="raw", help="Output directory")
+    ap.add_argument(
+        "--include-absolute-uri",
+        action="store_true",
+        help="Store absolute file:// URIs in sources.jsonl instead of workspace:/// relative URIs.",
+    )
     args = ap.parse_args()
 
     root = Path(args.root).expanduser().resolve()
@@ -234,7 +245,7 @@ def main() -> int:
 
     captured_at = iso_now()
     files = source_files(root)
-    sources = [build_source(root, path, captured_at) for path in files]
+    sources = [build_source(root, path, captured_at, include_absolute_uri=args.include_absolute_uri) for path in files]
     items: list[dict] = []
     for path, source in zip(files, sources):
         items.extend(build_items(root, path, source, captured_at))

--- a/scripts/mneme_llm_roundtrip.py
+++ b/scripts/mneme_llm_roundtrip.py
@@ -33,19 +33,21 @@ def run_json(cmd: list[str], ok_codes: tuple[int, ...] = (0,)) -> dict:
 def main() -> int:
     ap = argparse.ArgumentParser(description="Run the Mneme LLM-assisted compile loop.")
     ap.add_argument("--root", default=".", help="Workspace root")
-    ap.add_argument("--raw-out", default="/tmp/mneme-llm-raw", help="Raw evidence output dir")
-    ap.add_argument("--bundles-out", default="/tmp/mneme-llm-bundles", help="Prepared bundle output dir")
+    ap.add_argument("--raw-out", default=None, help="Raw evidence output dir")
+    ap.add_argument("--bundles-out", default=None, help="Prepared bundle output dir")
     ap.add_argument("--category", required=True, choices=["projects", "systems", "decisions", "incidents", "people", "timeline"], help="Category to focus on")
     ap.add_argument("--max-items", type=int, default=60, help="Max evidence items per bundle")
     ap.add_argument("--candidate", help="Optional candidate JSON to validate/materialize")
-    ap.add_argument("--materialize-out", default="/tmp/mneme-llm-materialized", help="Materialized output dir when --candidate is used")
+    ap.add_argument("--materialize-out", default=None, help="Materialized output dir when --candidate is used")
     ap.add_argument("--json", action="store_true", help="Emit JSON summary")
     args = ap.parse_args()
 
-    root = str(Path(args.root).expanduser().resolve())
-    raw_out = str(Path(args.raw_out).expanduser().resolve())
-    bundles_out = str(Path(args.bundles_out).expanduser().resolve())
-    materialize_out = str(Path(args.materialize_out).expanduser().resolve())
+    root_path = Path(args.root).expanduser().resolve()
+    root = str(root_path)
+    llm_base = root_path / ".mneme-llm"
+    raw_out = str(Path(args.raw_out).expanduser().resolve()) if args.raw_out else str((llm_base / "raw").resolve())
+    bundles_out = str(Path(args.bundles_out).expanduser().resolve()) if args.bundles_out else str((llm_base / "bundles").resolve())
+    materialize_out = str(Path(args.materialize_out).expanduser().resolve()) if args.materialize_out else str((llm_base / "materialized" / args.category).resolve())
 
     summary: dict[str, object] = {
         "root": root,

--- a/scripts/mneme_runtime_batch.py
+++ b/scripts/mneme_runtime_batch.py
@@ -29,6 +29,12 @@ def run_json(cmd: list[str], ok_codes: tuple[int, ...] = (0,)) -> dict[str, Any]
 
 
 def prepare_batch(args: argparse.Namespace) -> dict[str, Any]:
+    if not args.allow_agent_export:
+        raise RuntimeError(
+            "Refusing to prepare batch agent export tasks without explicit consent. "
+            "Re-run with --allow-agent-export if you intend to send Mneme evidence off-box via an agent/runtime."
+        )
+
     root = str(Path(args.root).expanduser().resolve())
     base_out = Path(args.out).expanduser().resolve()
     base_out.mkdir(parents=True, exist_ok=True)
@@ -49,6 +55,7 @@ def prepare_batch(args: argparse.Namespace) -> dict[str, Any]:
             "--raw-out", str(raw_out),
             "--bundles-out", str(bundles_out),
             "--materialize-out", str(materialize_out),
+            "--allow-agent-export",
         ])
         task_file = base_out / f"task-{category}.json"
         task_file.write_text(json.dumps(result, ensure_ascii=False, indent=2))
@@ -123,6 +130,11 @@ def main() -> int:
     p1.add_argument("--categories", nargs="*", choices=DEFAULT_CATEGORIES)
     p1.add_argument("--bundle-index", type=int, default=0)
     p1.add_argument("--max-items", type=int, default=25)
+    p1.add_argument(
+        "--allow-agent-export",
+        action="store_true",
+        help="Acknowledge that prepared taskPrompt files may be sent off-box via an agent/runtime.",
+    )
 
     p2 = sub.add_parser("apply-batch")
     p2.add_argument("--manifest", required=True)

--- a/scripts/mneme_runtime_orchestrate.py
+++ b/scripts/mneme_runtime_orchestrate.py
@@ -65,9 +65,18 @@ def build_task_prompt(category: str, bundle_payload: dict[str, Any]) -> str:
 
 
 def cmd_prepare_task(args: argparse.Namespace) -> int:
-    root = str(Path(args.root).expanduser().resolve())
-    raw_out = str(Path(args.raw_out).expanduser().resolve())
-    bundles_out = str(Path(args.bundles_out).expanduser().resolve())
+    root_path = Path(args.root).expanduser().resolve()
+    root = str(root_path)
+    runtime_base = root_path / ".mneme-runtime"
+    raw_out = str(Path(args.raw_out).expanduser().resolve()) if args.raw_out else str((runtime_base / "raw").resolve())
+    bundles_out = str(Path(args.bundles_out).expanduser().resolve()) if args.bundles_out else str((runtime_base / "bundles").resolve())
+
+    if not args.allow_agent_export:
+        raise RuntimeError(
+            "Refusing to prepare an agent export task without explicit consent. "
+            "Re-run with --allow-agent-export if you intend to send Mneme evidence off-box via an agent/runtime."
+        )
+
     summary = run_json([
         str(TOOLS["roundtrip"]),
         "--root", root,
@@ -84,13 +93,18 @@ def cmd_prepare_task(args: argparse.Namespace) -> int:
     bundle_file = Path(bundles_out) / bundle_meta["file"]
     bundle_payload = load_json(bundle_file)
     task_prompt = build_task_prompt(args.category, bundle_payload)
+    materialize_out = (
+        str(Path(args.materialize_out).expanduser().resolve())
+        if args.materialize_out
+        else str((runtime_base / "materialized" / args.category).resolve())
+    )
     out = {
         "category": args.category,
         "bundleIndex": args.bundle_index,
         "bundleFile": str(bundle_file),
         "rawOut": raw_out,
         "bundlesOut": bundles_out,
-        "materializeOut": str(Path(args.materialize_out).expanduser().resolve()),
+        "materializeOut": materialize_out,
         "taskPrompt": task_prompt,
         "bundleMeta": bundle_meta,
         "summary": summary,
@@ -148,9 +162,14 @@ def main() -> int:
     p1.add_argument("--category", required=True, choices=["projects", "systems", "decisions", "incidents", "people", "timeline"])
     p1.add_argument("--bundle-index", type=int, default=0)
     p1.add_argument("--max-items", type=int, default=60)
-    p1.add_argument("--raw-out", default="/tmp/mneme-runtime-raw")
-    p1.add_argument("--bundles-out", default="/tmp/mneme-runtime-bundles")
-    p1.add_argument("--materialize-out", default="/tmp/mneme-runtime-materialized")
+    p1.add_argument("--raw-out", default=None)
+    p1.add_argument("--bundles-out", default=None)
+    p1.add_argument("--materialize-out", default=None)
+    p1.add_argument(
+        "--allow-agent-export",
+        action="store_true",
+        help="Acknowledge that the prepared taskPrompt may be sent off-box via an agent/runtime.",
+    )
 
     p2 = sub.add_parser("apply-result")
     p2.add_argument("--category", required=True, choices=["projects", "systems", "decisions", "incidents", "people", "timeline"])

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -81,6 +81,7 @@ class MnemeSmokeTests(unittest.TestCase):
             '--raw-out', str(raw_out),
             '--bundles-out', str(bundles_out),
             '--materialize-out', str(materialize_out),
+            '--allow-agent-export',
         ])
         self.assertEqual(data['category'], 'people')
         self.assertEqual(data['bundleMeta']['category'], 'people')


### PR DESCRIPTION
## Summary
This PR hardens Mneme's privacy defaults in three low-risk ways:

1. use workspace-relative source URIs by default during ingest
2. stop defaulting LLM/runtime artifacts into `/tmp`
3. require explicit acknowledgment before preparing agent-export task payloads

Closes #14.

## Changes

### Ingest
- `scripts/mneme_ingest_memory.py`
- default `EvidenceSource.uri` is now `workspace:///...` instead of an absolute `file://...` path
- added `--include-absolute-uri` for explicit opt-in when absolute file URIs are actually needed

### Local LLM artifacts
- `scripts/mneme_llm_roundtrip.py`
- default output directories now live under `<root>/.mneme-llm/...` instead of `/tmp/...`

### Runtime export boundary
- `scripts/mneme_runtime_orchestrate.py`
- `scripts/mneme_runtime_batch.py`
- preparing agent-export task payloads now requires `--allow-agent-export`
- runtime defaults now live under `<root>/.mneme-runtime/...` instead of `/tmp/...`

### Docs/tests
- updated runtime docs/examples to show the explicit export flag
- updated smoke test coverage accordingly

## Validation
```bash
python3 -m unittest discover -s tests -p 'test_*.py'
```

## Follow-up
This PR does **not** implement deeper bundle sanitization/redaction before export.
That still feels like a good next hardening pass, but I kept this patch focused and boring.

— Lyra ✨ (OpenClaw)